### PR TITLE
Support configuring azure openai for backend and llamaparse services

### DIFF
--- a/charts/llamacloud/Chart.yaml
+++ b/charts/llamacloud/Chart.yaml
@@ -45,5 +45,5 @@ keywords:
 - llamacloud
 - rag
 
-version: 0.1.3
-appVersion: "0.1.3"
+version: 0.1.4
+appVersion: "0.1.4"

--- a/charts/llamacloud/README.md
+++ b/charts/llamacloud/README.md
@@ -127,6 +127,12 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `backend.config.logLevel`                            | Log level for the backend                                                                                         | `info`                          |
 | `backend.config.openAiApiKey`                        | (Required) OpenAI API key                                                                                         | `""`                            |
 | `backend.config.existingOpenAiApiKeySecret`          | Name of the existing secret to use for the OpenAI API key                                                         | `""`                            |
+| `backend.config.azureOpenAi.enabled`                 | Enable Azure OpenAI for backend                                                                                   | `false`                         |
+| `backend.config.azureOpenAi.existingSecret`          | Name of the existing secret to use for the Azure OpenAI API key                                                   | `""`                            |
+| `backend.config.azureOpenAi.key`                     | Azure OpenAI API key                                                                                              | `""`                            |
+| `backend.config.azureOpenAi.endpoint`                | Azure OpenAI endpoint                                                                                             | `""`                            |
+| `backend.config.azureOpenAi.deploymentName`          | Azure OpenAI deployment                                                                                           | `""`                            |
+| `backend.config.azureOpenAi.apiVersion`              | Azure OpenAI API version                                                                                          | `""`                            |
 | `backend.config.oidc.existingSecretName`             | Name of the existing secret to use for OIDC configuration                                                         | `""`                            |
 | `backend.config.oidc.discoveryUrl`                   | OIDC discovery URL                                                                                                | `""`                            |
 | `backend.config.oidc.clientId`                       | OIDC client ID                                                                                                    | `""`                            |
@@ -297,7 +303,13 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `llamaParse.config.maxPdfPages`                         | Maximum number of pages to parse in a PDF                                   | `1200`                             |
 | `llamaParse.config.openAiApiKey`                        | OpenAI API key                                                              | `""`                               |
 | `llamaParse.config.existingOpenAiApiKeySecret`          | Name of the existing secret to use for the OpenAI API key                   | `""`                               |
-| `llamaParse.config.anthropicApiKey`                     | Anthropic                                                                   | `""`                               |
+| `llamaParse.config.azureOpenAi.enabled`                 | Enable Azure OpenAI for LlamaParse                                          | `false`                            |
+| `llamaParse.config.azureOpenAi.existingSecret`          | Name of the existing secret to use for the Azure OpenAI API key             | `""`                               |
+| `llamaParse.config.azureOpenAi.key`                     | Azure OpenAI API key                                                        | `""`                               |
+| `llamaParse.config.azureOpenAi.endpoint`                | Azure OpenAI endpoint                                                       | `""`                               |
+| `llamaParse.config.azureOpenAi.deploymentName`          | Azure OpenAI deployment                                                     | `""`                               |
+| `llamaParse.config.azureOpenAi.apiVersion`              | Azure OpenAI API version                                                    | `""`                               |
+| `llamaParse.config.anthropicApiKey`                     | Anthropic API key                                                           | `""`                               |
 | `llamaParse.config.existingAnthropicApiKeySecret`       | Name of the existing secret to use for the Anthropic API key                | `""`                               |
 | `llamaParse.config.s3UploadBucket`                      | S3 bucket to upload files to                                                | `llama-platform-file-parsing`      |
 | `llamaParse.config.s3OutputBucket`                      | S3 bucket to output files to                                                | `llama-platform-file-parsing`      |

--- a/charts/llamacloud/README.md
+++ b/charts/llamacloud/README.md
@@ -12,7 +12,7 @@ helm repo add llamaindex https://run-llama.github.io/helm-charts
 helm repo update
 
 # Install the basic version of the chart
-helm install my-llamacloud-release llamaindex/llamacloud --version 0.1.3
+helm install my-llamacloud-release llamaindex/llamacloud --version 0.1.4
 ```
 
 ## Prerequisites
@@ -88,7 +88,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `frontend.replicas`                                   | Number of replicas of Frontend Deployment                                                                         | `1`                              |
 | `frontend.image.registry`                             | Frontend Image registry                                                                                           | `docker.io`                      |
 | `frontend.image.repository`                           | Frontend Image repository                                                                                         | `llamaindex/llamacloud-frontend` |
-| `frontend.image.tag`                                  | Frontend Image tag                                                                                                | `0.1.3`                          |
+| `frontend.image.tag`                                  | Frontend Image tag                                                                                                | `0.1.4`                          |
 | `frontend.image.pullPolicy`                           | Frontend Image pull policy                                                                                        | `IfNotPresent`                   |
 | `frontend.service.type`                               | Frontend Service type                                                                                             | `ClusterIP`                      |
 | `frontend.service.port`                               | Frontend Service port                                                                                             | `3000`                           |
@@ -140,7 +140,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `backend.replicas`                                   | Number of replicas of Backend Deployment                                                                          | `1`                             |
 | `backend.image.registry`                             | Backend Image registry                                                                                            | `docker.io`                     |
 | `backend.image.repository`                           | Backend Image repository                                                                                          | `llamaindex/llamacloud-backend` |
-| `backend.image.tag`                                  | Backend Image tag                                                                                                 | `0.1.3`                         |
+| `backend.image.tag`                                  | Backend Image tag                                                                                                 | `0.1.4`                         |
 | `backend.image.pullPolicy`                           | Backend Image pull policy                                                                                         | `IfNotPresent`                  |
 | `backend.service.type`                               | Backend Service type                                                                                              | `ClusterIP`                     |
 | `backend.service.port`                               | Backend Service port                                                                                              | `8000`                          |
@@ -198,7 +198,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `jobsService.replicas`                                   | Number of replicas of JobsService Deployment                                                                      | `1`                                  |
 | `jobsService.image.registry`                             | JobsService Image registry                                                                                        | `docker.io`                          |
 | `jobsService.image.repository`                           | JobsService Image repository                                                                                      | `llamaindex/llamacloud-jobs-service` |
-| `jobsService.image.tag`                                  | JobsService Image tag                                                                                             | `0.1.3`                              |
+| `jobsService.image.tag`                                  | JobsService Image tag                                                                                             | `0.1.4`                              |
 | `jobsService.image.pullPolicy`                           | JobsService Image pull policy                                                                                     | `IfNotPresent`                       |
 | `jobsService.service.type`                               | JobsService Service type                                                                                          | `ClusterIP`                          |
 | `jobsService.service.port`                               | JobsService Service port                                                                                          | `8002`                               |
@@ -246,7 +246,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `jobsWorker.replicas`                                   | Number of replicas of JobsWorker Deployment                                                                       | `1`                                 |
 | `jobsWorker.image.registry`                             | JobsWorker Image registry                                                                                         | `docker.io`                         |
 | `jobsWorker.image.repository`                           | JobsWorker Image repository                                                                                       | `llamaindex/llamacloud-jobs-worker` |
-| `jobsWorker.image.tag`                                  | JobsWorker Image tag                                                                                              | `0.1.3`                             |
+| `jobsWorker.image.tag`                                  | JobsWorker Image tag                                                                                              | `0.1.4`                             |
 | `jobsWorker.image.pullPolicy`                           | JobsWorker Image pull policy                                                                                      | `IfNotPresent`                      |
 | `jobsWorker.service.type`                               | JobsWorker Service type                                                                                           | `ClusterIP`                         |
 | `jobsWorker.service.port`                               | JobsWorker Service port                                                                                           | `8001`                              |
@@ -317,7 +317,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `llamaParse.replicas`                                   | Number of replicas of LlamaParse Deployment                                 | `2`                                |
 | `llamaParse.image.registry`                             | LlamaParse Image registry                                                   | `docker.io`                        |
 | `llamaParse.image.repository`                           | LlamaParse Image repository                                                 | `llamaindex/llamacloud-llamaparse` |
-| `llamaParse.image.tag`                                  | LlamaParse Image tag                                                        | `0.1.3`                            |
+| `llamaParse.image.tag`                                  | LlamaParse Image tag                                                        | `0.1.4`                            |
 | `llamaParse.image.pullPolicy`                           | LlamaParse Image pull policy                                                | `IfNotPresent`                     |
 | `llamaParse.serviceAccount.create`                      | Whether or not to create a new service account                              | `true`                             |
 | `llamaParse.serviceAccount.name`                        | Name of the service account                                                 | `""`                               |
@@ -359,7 +359,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `llamaParseOcr.replicas`                                   | Number of replicas of LlamaParseOcr Deployment                                              | `2`                                    |
 | `llamaParseOcr.image.registry`                             | LlamaParseOcr Image registry                                                                | `docker.io`                            |
 | `llamaParseOcr.image.repository`                           | LlamaParseOcr Image repository                                                              | `llamaindex/llamacloud-llamaparse-ocr` |
-| `llamaParseOcr.image.tag`                                  | LlamaParseOcr Image tag                                                                     | `0.1.3`                                |
+| `llamaParseOcr.image.tag`                                  | LlamaParseOcr Image tag                                                                     | `0.1.4`                                |
 | `llamaParseOcr.image.pullPolicy`                           | LlamaParseOcr Image pull policy                                                             | `IfNotPresent`                         |
 | `llamaParseOcr.service.type`                               | LlamaParseOcr Service type                                                                  | `ClusterIP`                            |
 | `llamaParseOcr.service.port`                               | LlamaParseOcr Service port                                                                  | `8080`                                 |
@@ -414,7 +414,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `usage.replicas`                                   | Number of replicas of usage Deployment                                                                            | `1`                           |
 | `usage.image.registry`                             | Usage Image registry                                                                                              | `docker.io`                   |
 | `usage.image.repository`                           | Usage Image repository                                                                                            | `llamaindex/llamacloud-usage` |
-| `usage.image.tag`                                  | Usage Image tag                                                                                                   | `0.1.3`                       |
+| `usage.image.tag`                                  | Usage Image tag                                                                                                   | `0.1.4`                       |
 | `usage.image.pullPolicy`                           | Usage Image pull policy                                                                                           | `IfNotPresent`                |
 | `usage.service.type`                               | Usage Service type                                                                                                | `ClusterIP`                   |
 | `usage.service.port`                               | Usage Service port                                                                                                | `8005`                        |

--- a/charts/llamacloud/templates/backend/deployment.yaml
+++ b/charts/llamacloud/templates/backend/deployment.yaml
@@ -136,6 +136,10 @@ spec:
           - secretRef:
               name: {{ .Values.backend.config.existingOpenAiApiKeySecretName }}
           {{- end }}
+          {{- if and .Values.backend.config.azureOpenAi.enabled .Values.backend.config.azureOpenAi.existingSecret }}
+          - secretRef:
+              name: {{ .Values.backend.config.azureOpenAi.existingSecret }}
+          {{- end }}
           {{- if not .Values.backend.externalSecrets.enabled }}
           - secretRef:
               name: {{ include "llamacloud.fullname" . }}-{{ .Values.backend.name }}-secret

--- a/charts/llamacloud/templates/backend/secret.yaml
+++ b/charts/llamacloud/templates/backend/secret.yaml
@@ -15,6 +15,12 @@ data:
   {{- if and .Values.backend.config.openAiApiKey (not .Values.backend.existingOpenAiApiKeySecretName) }}
   LC_OPENAI_API_KEY: {{ .Values.backend.config.openAiApiKey | b64enc | quote }}
   {{- end }}
+  {{- if and .Values.backend.config.azureOpenAi.enabled (not .Values.backend.config.azureOpenAi.existingSecret) }}
+  LC_OPENAI_API_KEY: {{ .Values.backend.config.azureOpenAi.key | b64enc | quote }}
+  OPENAI_BASE_URL: {{ .Values.backend.config.azureOpenAi.endpoint | b64enc | quote }}
+  AZURE_OPENAI_DEPLOYMENT_NAME: {{ .Values.backend.config.azureOpenAi.deploymentName | b64enc | quote }}
+  AZURE_OPENAI_API_VERSION: {{ .Values.backend.config.azureOpenAi.apiVersion | b64enc | quote }}
+  {{- end }}
   {{- if .Values.s3proxy.enabled }}
   S3_ENDPOINT_URL: {{ printf "http://%s-%s:%d" (include "llamacloud.fullname" .) .Values.s3proxy.name (.Values.s3proxy.service.port | int) | b64enc | quote }}
   {{- end }}

--- a/charts/llamacloud/templates/jobs-service/deployment.yaml
+++ b/charts/llamacloud/templates/jobs-service/deployment.yaml
@@ -124,6 +124,10 @@ spec:
           - secretRef:
               name: {{ .Values.backend.config.existingOpenAiApiKeySecretName }}
           {{- end }}
+          {{- if and .Values.backend.config.azureOpenAi.enabled .Values.backend.config.azureOpenAi.existingSecret }}
+          - secretRef:
+              name: {{ .Values.backend.config.azureOpenAi.existingSecret }}
+          {{- end }}
           {{- if not .Values.jobsService.externalSecrets.enabled }}
           - secretRef:
               name: {{ include "llamacloud.fullname" . }}-{{ .Values.jobsService.name }}-secret

--- a/charts/llamacloud/templates/jobs-service/secret.yaml
+++ b/charts/llamacloud/templates/jobs-service/secret.yaml
@@ -15,6 +15,12 @@ data:
   {{- if and .Values.backend.config.openAiApiKey (not .Values.backend.existingOpenAiApiKeySecretName) }}
   LC_OPENAI_API_KEY: {{ .Values.backend.config.openAiApiKey | b64enc | quote }}
   {{- end }}
+  {{- if and .Values.backend.config.azureOpenAi.enabled (not .Values.backend.config.azureOpenAi.existingSecret) }}
+  LC_OPENAI_API_KEY: {{ .Values.backend.config.azureOpenAi.key | b64enc | quote }}
+  OPENAI_BASE_URL: {{ .Values.backend.config.azureOpenAi.endpoint | b64enc | quote }}
+  AZURE_OPENAI_DEPLOYMENT_NAME: {{ .Values.backend.config.azureOpenAi.deploymentName | b64enc | quote }}
+  AZURE_OPENAI_API_VERSION: {{ .Values.backend.config.azureOpenAi.apiVersion | b64enc | quote }}
+  {{- end }}
   {{- if .Values.s3proxy.enabled }}
   S3_ENDPOINT_URL: {{ printf "http://%s-%s:%d" (include "llamacloud.fullname" .) .Values.s3proxy.name (.Values.s3proxy.service.port | int) | b64enc | quote }}
   {{- end }}

--- a/charts/llamacloud/templates/jobs-worker/deployment.yaml
+++ b/charts/llamacloud/templates/jobs-worker/deployment.yaml
@@ -134,6 +134,10 @@ spec:
           - secretRef:
               name: {{ .Values.backend.config.existingOpenAiApiKeySecretName }}
           {{- end }}
+          {{- if and .Values.backend.config.azureOpenAi.enabled .Values.backend.config.azureOpenAi.existingSecret }}
+          - secretRef:
+              name: {{ .Values.backend.config.azureOpenAi.existingSecret }}
+          {{- end }}
           {{- if not .Values.jobsWorker.externalSecrets.enabled }}
           - secretRef:
               name: {{ include "llamacloud.fullname" . }}-{{ .Values.jobsWorker.name }}-secret

--- a/charts/llamacloud/templates/jobs-worker/secret.yaml
+++ b/charts/llamacloud/templates/jobs-worker/secret.yaml
@@ -15,6 +15,12 @@ data:
   {{- if and .Values.backend.config.openAiApiKey (not .Values.backend.existingOpenAiApiKeySecretName) }}
   LC_OPENAI_API_KEY: {{ .Values.backend.config.openAiApiKey | b64enc | quote }}
   {{- end }}
+  {{- if and .Values.backend.config.azureOpenAi.enabled (not .Values.backend.config.azureOpenAi.existingSecret) }}
+  LC_OPENAI_API_KEY: {{ .Values.backend.config.azureOpenAi.key | b64enc | quote }}
+  OPENAI_BASE_URL: {{ .Values.backend.config.azureOpenAi.endpoint | b64enc | quote }}
+  AZURE_OPENAI_DEPLOYMENT_NAME: {{ .Values.backend.config.azureOpenAi.deploymentName | b64enc | quote }}
+  AZURE_OPENAI_API_VERSION: {{ .Values.backend.config.azureOpenAi.apiVersion | b64enc | quote }}
+  {{- end }}
   {{- if .Values.s3proxy.enabled }}
   S3_ENDPOINT_URL: {{ printf "http://%s-%s:%d" (include "llamacloud.fullname" .) .Values.s3proxy.name (.Values.s3proxy.service.port | int) | b64enc | quote }}
   {{- end }}

--- a/charts/llamacloud/templates/llamaparse/configmap.yaml
+++ b/charts/llamacloud/templates/llamaparse/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "llamacloud.annotations" . | nindent 4 }}
 data:
+  CLOUD_PROVIDER: {{ .Values.global.cloudProvider | quote }}
   DEBUG_MODE: {{ .Values.llamaParse.config.debugMode | default false | quote }}
   MAX_PDF_PAGES: {{ .Values.llamaParse.config.maxPdfPages | default 1200 | quote }}
   JOB_SERVICE_URL: {{ printf "http://%s-%s:%d" (include "llamacloud.fullname" .) .Values.jobsService.name (.Values.jobsService.service.port | int) | quote }}

--- a/charts/llamacloud/templates/llamaparse/deployment.yaml
+++ b/charts/llamacloud/templates/llamaparse/deployment.yaml
@@ -102,6 +102,10 @@ spec:
           - secretRef:
               name: {{ .Values.llamaParse.config.existingOpenAiApiKeySecret }}
           {{- end }}
+          {{- if and .Values.llamaParse.config.azureOpenAi.enabled .Values.llamaParse.config.azureOpenAi.existingSecret }}
+          - secretRef:
+              name: {{ .Values.llamaParse.config.azureOpenAi.existingSecret }}
+          {{- end }}
           {{- if .Values.llamaParse.config.existingAnthropicApiKeySecret }}
           - secretRef:
               name: {{ .Values.llamaParse.config.existingAnthropicApiKeySecret }}

--- a/charts/llamacloud/templates/llamaparse/secret.yaml
+++ b/charts/llamacloud/templates/llamaparse/secret.yaml
@@ -15,6 +15,12 @@ data:
   {{- if and .Values.llamaParse.config.openAiApiKey (not .Values.llamaParse.config.existingOpenAiApiKeySecret) }}
   OPENAI_API_KEY: {{ .Values.llamaParse.config.openAiApiKey | b64enc | quote }}
   {{- end }}
+  {{- if and .Values.llamaParse.config.azureOpenAi.enabled (not .Values.llamaParse.config.azureOpenAi.existingSecret ) }}
+  AZURE_OPENAI_KEY: {{ .Values.llamaParse.config.azureOpenAi.key | b64enc | quote }}
+  AZURE_OPENAI_ENDPOINT: {{ .Values.llamaParse.config.azureOpenAi.endpoint | b64enc | quote }}
+  AZURE_OPENAI_DEPLOYMENT_NAME: {{ .Values.llamaParse.config.azureOpenAi.deploymentName | b64enc | quote }}
+  AZURE_OPENAI_API_VERSION: {{ .Values.llamaParse.config.azureOpenAi.apiVersion | b64enc | quote }}
+  {{- end }}
   {{- if and .Values.llamaParse.config.anthropicAPIKey (not .Values.llamaParse.config.existingAnthropicAPIKeySecret) }}
   ANTHROPIC_API_KEY: {{ .Values.llamaParse.config.anthropicAPIKey | default "" | b64enc | quote }}
   {{- end }}

--- a/charts/llamacloud/values.yaml
+++ b/charts/llamacloud/values.yaml
@@ -75,7 +75,7 @@ frontend:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-frontend
-    tag: 0.1.3
+    tag: 0.1.4
     pullPolicy: IfNotPresent
 
   ## @param frontend.service.type Frontend Service type
@@ -199,6 +199,21 @@ backend:
     openAiApiKey: ""
     existingOpenAiApiKeySecret: ""
 
+    ## Backend Azure OpenAI configuration
+    ## @param backend.config.azureOpenAi.enabled Enable Azure OpenAI for backend
+    ## @param backend.config.azureOpenAi.existingSecret Name of the existing secret to use for the Azure OpenAI API key
+    ## @param backend.config.azureOpenAi.key Azure OpenAI API key
+    ## @param backend.config.azureOpenAi.endpoint Azure OpenAI endpoint
+    ## @param backend.config.azureOpenAi.deploymentName Azure OpenAI deployment
+    ## @param backend.config.azureOpenAi.apiVersion Azure OpenAI API version
+    azureOpenAi:
+      enabled: false
+      existingSecret: ""
+      key: ""
+      endpoint: ""
+      deploymentName: ""
+      apiVersion: ""
+
     ## Backend OpenID Connect configuration
     ## @param backend.config.oidc.existingSecretName Name of the existing secret to use for OIDC configuration
     ## @param backend.config.oidc.discoveryUrl OIDC discovery URL
@@ -221,7 +236,7 @@ backend:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-backend
-    tag: 0.1.3
+    tag: 0.1.4
     pullPolicy: IfNotPresent
 
   ## Backend Service information
@@ -408,7 +423,7 @@ jobsService:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-jobs-service
-    tag: 0.1.3
+    tag: 0.1.4
     pullPolicy: IfNotPresent
 
   ## JobsService Service information\
@@ -565,7 +580,7 @@ jobsWorker:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-jobs-worker
-    tag: 0.1.3
+    tag: 0.1.4
     pullPolicy: IfNotPresent
 
   ## JobsWorker Service information
@@ -735,18 +750,35 @@ llamaParse:
 
   config:
     ## @param llamaParse.config.maxPdfPages Maximum number of pages to parse in a PDF
+    maxPdfPages: 1200
+
     ## @param llamaParse.config.openAiApiKey OpenAI API key
     ## @param llamaParse.config.existingOpenAiApiKeySecret Name of the existing secret to use for the OpenAI API key
-    ## @param llamaParse.config.anthropicApiKey Anthropic
+    openAiApiKey: ""
+    existingOpenAiApiKeySecret: ""
+
+    ## @param llamaParse.config.azureOpenAi.enabled Enable Azure OpenAI for LlamaParse
+    ## @param llamaParse.config.azureOpenAi.existingSecret Name of the existing secret to use for the Azure OpenAI API key
+    ## @param llamaParse.config.azureOpenAi.key Azure OpenAI API key
+    ## @param llamaParse.config.azureOpenAi.endpoint Azure OpenAI endpoint
+    ## @param llamaParse.config.azureOpenAi.deploymentName Azure OpenAI deployment
+    ## @param llamaParse.config.azureOpenAi.apiVersion Azure OpenAI API version
+    azureOpenAi:
+      enabled: false
+      existingSecret: ""
+      key: ""
+      endpoint: ""
+      deploymentName: ""
+      apiVersion: ""
+
+    ## @param llamaParse.config.anthropicApiKey Anthropic API key
     ## @param llamaParse.config.existingAnthropicApiKeySecret Name of the existing secret to use for the Anthropic API key
+    anthropicApiKey: ""
+    existingAnthropicApiKeySecret: ""
+
     ## @param llamaParse.config.s3UploadBucket S3 bucket to upload files to
     ## @param llamaParse.config.s3OutputBucket S3 bucket to output files to
     ## @param llamaParse.config.s3OutputBucketTemp S3 bucket to output temporary files to
-    maxPdfPages: 1200
-    openAiApiKey: ""
-    existingOpenAiApiKeySecret: ""
-    anthropicApiKey: ""
-    existingAnthropicApiKeySecret: ""
     s3UploadBucket: "llama-platform-file-parsing"
     s3OutputBucket: "llama-platform-file-parsing"
     s3OutputBucketTemp: "llama-platform-file-parsing"
@@ -762,7 +794,7 @@ llamaParse:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-llamaparse
-    tag: 0.1.3
+    tag: 0.1.4
     pullPolicy: IfNotPresent
 
   ## ServiceAccount configuration
@@ -893,7 +925,7 @@ llamaParseOcr:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-llamaparse-ocr
-    tag: 0.1.3
+    tag: 0.1.4
     pullPolicy: IfNotPresent
 
   ## LlamaParseOcr Service information
@@ -1049,7 +1081,7 @@ usage:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-usage
-    tag: 0.1.3
+    tag: 0.1.4
     pullPolicy: IfNotPresent
 
   ## Usage Service information


### PR DESCRIPTION
This pr allows the user to use [Azure OpenAI service](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) instead of OpenAI as an LLM provider. 