### PR TITLE
chore Bump chart to version 0.1.11

### DIFF
--- a/charts/llamacloud/Chart.yaml
+++ b/charts/llamacloud/Chart.yaml
@@ -45,5 +45,5 @@ keywords:
 - llamacloud
 - rag
 
-version: 0.1.10
-appVersion: "0.1.10"
+version: 0.1.11
+appVersion: "0.1.11"

--- a/charts/llamacloud/README.md
+++ b/charts/llamacloud/README.md
@@ -88,7 +88,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `frontend.replicas`                                   | Number of replicas of Frontend Deployment                                                                         | `1`                              |
 | `frontend.image.registry`                             | Frontend Image registry                                                                                           | `docker.io`                      |
 | `frontend.image.repository`                           | Frontend Image repository                                                                                         | `llamaindex/llamacloud-frontend` |
-| `frontend.image.tag`                                  | Frontend Image tag                                                                                                | `0.1.8`                          |
+| `frontend.image.tag`                                  | Frontend Image tag                                                                                                | `0.1.11`                         |
 | `frontend.image.pullPolicy`                           | Frontend Image pull policy                                                                                        | `IfNotPresent`                   |
 | `frontend.service.type`                               | Frontend Service type                                                                                             | `ClusterIP`                      |
 | `frontend.service.port`                               | Frontend Service port                                                                                             | `3000`                           |
@@ -140,7 +140,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `backend.replicas`                                   | Number of replicas of Backend Deployment                                                                          | `1`                             |
 | `backend.image.registry`                             | Backend Image registry                                                                                            | `docker.io`                     |
 | `backend.image.repository`                           | Backend Image repository                                                                                          | `llamaindex/llamacloud-backend` |
-| `backend.image.tag`                                  | Backend Image tag                                                                                                 | `0.1.8`                         |
+| `backend.image.tag`                                  | Backend Image tag                                                                                                 | `0.1.11`                        |
 | `backend.image.pullPolicy`                           | Backend Image pull policy                                                                                         | `IfNotPresent`                  |
 | `backend.service.type`                               | Backend Service type                                                                                              | `ClusterIP`                     |
 | `backend.service.port`                               | Backend Service port                                                                                              | `8000`                          |
@@ -198,7 +198,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `jobsService.replicas`                                   | Number of replicas of JobsService Deployment                                                                      | `1`                                  |
 | `jobsService.image.registry`                             | JobsService Image registry                                                                                        | `docker.io`                          |
 | `jobsService.image.repository`                           | JobsService Image repository                                                                                      | `llamaindex/llamacloud-jobs-service` |
-| `jobsService.image.tag`                                  | JobsService Image tag                                                                                             | `0.1.8`                              |
+| `jobsService.image.tag`                                  | JobsService Image tag                                                                                             | `0.1.11`                             |
 | `jobsService.image.pullPolicy`                           | JobsService Image pull policy                                                                                     | `IfNotPresent`                       |
 | `jobsService.service.type`                               | JobsService Service type                                                                                          | `ClusterIP`                          |
 | `jobsService.service.port`                               | JobsService Service port                                                                                          | `8002`                               |
@@ -246,7 +246,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `jobsWorker.replicas`                                   | Number of replicas of JobsWorker Deployment                                                                       | `1`                                 |
 | `jobsWorker.image.registry`                             | JobsWorker Image registry                                                                                         | `docker.io`                         |
 | `jobsWorker.image.repository`                           | JobsWorker Image repository                                                                                       | `llamaindex/llamacloud-jobs-worker` |
-| `jobsWorker.image.tag`                                  | JobsWorker Image tag                                                                                              | `0.1.8`                             |
+| `jobsWorker.image.tag`                                  | JobsWorker Image tag                                                                                              | `0.1.11`                            |
 | `jobsWorker.image.pullPolicy`                           | JobsWorker Image pull policy                                                                                      | `IfNotPresent`                      |
 | `jobsWorker.service.type`                               | JobsWorker Service type                                                                                           | `ClusterIP`                         |
 | `jobsWorker.service.port`                               | JobsWorker Service port                                                                                           | `8001`                              |
@@ -317,7 +317,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `llamaParse.replicas`                                   | Number of replicas of LlamaParse Deployment                                 | `2`                                |
 | `llamaParse.image.registry`                             | LlamaParse Image registry                                                   | `docker.io`                        |
 | `llamaParse.image.repository`                           | LlamaParse Image repository                                                 | `llamaindex/llamacloud-llamaparse` |
-| `llamaParse.image.tag`                                  | LlamaParse Image tag                                                        | `0.1.8`                            |
+| `llamaParse.image.tag`                                  | LlamaParse Image tag                                                        | `0.1.11`                           |
 | `llamaParse.image.pullPolicy`                           | LlamaParse Image pull policy                                                | `IfNotPresent`                     |
 | `llamaParse.serviceAccount.create`                      | Whether or not to create a new service account                              | `true`                             |
 | `llamaParse.serviceAccount.name`                        | Name of the service account                                                 | `""`                               |
@@ -359,7 +359,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `llamaParseOcr.replicas`                                   | Number of replicas of LlamaParseOcr Deployment                                              | `2`                                    |
 | `llamaParseOcr.image.registry`                             | LlamaParseOcr Image registry                                                                | `docker.io`                            |
 | `llamaParseOcr.image.repository`                           | LlamaParseOcr Image repository                                                              | `llamaindex/llamacloud-llamaparse-ocr` |
-| `llamaParseOcr.image.tag`                                  | LlamaParseOcr Image tag                                                                     | `0.1.8`                                |
+| `llamaParseOcr.image.tag`                                  | LlamaParseOcr Image tag                                                                     | `0.1.11`                               |
 | `llamaParseOcr.image.pullPolicy`                           | LlamaParseOcr Image pull policy                                                             | `IfNotPresent`                         |
 | `llamaParseOcr.service.type`                               | LlamaParseOcr Service type                                                                  | `ClusterIP`                            |
 | `llamaParseOcr.service.port`                               | LlamaParseOcr Service port                                                                  | `8080`                                 |
@@ -414,7 +414,7 @@ For more information about using this chart, feel free to visit the [Official Ll
 | `usage.replicas`                                   | Number of replicas of usage Deployment                                                                            | `1`                           |
 | `usage.image.registry`                             | Usage Image registry                                                                                              | `docker.io`                   |
 | `usage.image.repository`                           | Usage Image repository                                                                                            | `llamaindex/llamacloud-usage` |
-| `usage.image.tag`                                  | Usage Image tag                                                                                                   | `0.1.8`                       |
+| `usage.image.tag`                                  | Usage Image tag                                                                                                   | `0.1.11`                      |
 | `usage.image.pullPolicy`                           | Usage Image pull policy                                                                                           | `IfNotPresent`                |
 | `usage.service.type`                               | Usage Service type                                                                                                | `ClusterIP`                   |
 | `usage.service.port`                               | Usage Service port                                                                                                | `8005`                        |

--- a/charts/llamacloud/values.yaml
+++ b/charts/llamacloud/values.yaml
@@ -76,7 +76,7 @@ frontend:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-frontend
-    tag: 0.1.10
+    tag: 0.1.11
     pullPolicy: IfNotPresent
 
   ## @param frontend.service.type Frontend Service type
@@ -237,7 +237,7 @@ backend:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-backend
-    tag: 0.1.10
+    tag: 0.1.11
     pullPolicy: IfNotPresent
 
   ## Backend Service information
@@ -424,7 +424,7 @@ jobsService:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-jobs-service
-    tag: 0.1.10
+    tag: 0.1.11
     pullPolicy: IfNotPresent
 
   ## JobsService Service information\
@@ -581,7 +581,7 @@ jobsWorker:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-jobs-worker
-    tag: 0.1.10
+    tag: 0.1.11
     pullPolicy: IfNotPresent
 
   ## JobsWorker Service information
@@ -795,7 +795,7 @@ llamaParse:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-llamaparse
-    tag: 0.1.10
+    tag: 0.1.11
     pullPolicy: IfNotPresent
 
   ## ServiceAccount configuration
@@ -926,7 +926,7 @@ llamaParseOcr:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-llamaparse-ocr
-    tag: 0.1.10
+    tag: 0.1.11
     pullPolicy: IfNotPresent
 
   ## LlamaParseOcr Service information
@@ -1082,7 +1082,7 @@ usage:
   image:
     registry: docker.io
     repository: llamaindex/llamacloud-usage
-    tag: 0.1.10
+    tag: 0.1.11
     pullPolicy: IfNotPresent
 
   ## Usage Service information


### PR DESCRIPTION
Informal release notes for those who find their way here:

- (llamaparse): Fixes Azure OpenAI client connection in
- (llamaparse): Changes the `parse_raw_file_job` queue to be a priority queue. Since recreating a queue in rabbitmq can require some surgery, the easiest path forward without recreating the entire rabbitmq deployment is to manually delete the queue by whichever means are easiest for you.