### PR TITLE
Add simple kustomize bundle for llamaparse-ocr service

### DIFF
--- a/charts/llamacloud/kubernetes/README.md
+++ b/charts/llamacloud/kubernetes/README.md
@@ -1,0 +1,16 @@
+# LlamaCloud Kubernetes Manifests
+
+This directory contains the manifests via kustomize bundles for the LlamaCloud services.
+
+## Requirements
+
+- [kustomize](https://kustomize.io) version 5.0.0 or higher
+- [kubectl](https://kubernetes.io/docs/reference/kubectl/)
+
+## Supported Services
+
+- [llamaparse-ocr](./llamaparse-ocr/README.md)
+
+## License Key
+
+To obtain a license key, please contact us at [support@llamacloud.com](mailto:support@llamacloud.com).

--- a/charts/llamacloud/kubernetes/llamaparse-ocr/README.md
+++ b/charts/llamacloud/kubernetes/llamaparse-ocr/README.md
@@ -1,0 +1,20 @@
+# LlamaParse OCR Manifests
+
+This directory contains the manifests for the LlamaParse OCR service. Provided here is a simple Kustomize setup for deploying the llamaparse-ocr service to your Kubernetes cluster. This is intended to be used as a starting point for your own deployment.
+
+## License Key
+
+To obtain a license key, please contact us at [support@llamacloud.com](mailto:support@llamacloud.com).
+
+## Basic Usage
+
+```bash
+export LLAMACLOUD_LICENSE_KEY=<your-license-key>
+echo "$LLAMACLOUD_LICENSE_KEY" > license-key
+
+# Build the manifests and view the output
+kustomize build .
+
+# Build and apply the manifests to your cluster
+kustomize build . | kubectl apply -f -
+```

--- a/charts/llamacloud/kubernetes/llamaparse-ocr/base/deployment.yaml
+++ b/charts/llamacloud/kubernetes/llamaparse-ocr/base/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llamaparse-ocr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: llamacloud-llamaparse-ocr
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: llamacloud-llamaparse-ocr
+    spec:
+      serviceAccountName: llamacloud-llamaparse-ocr
+      containers:
+        - name: llamaparse-ocr
+          image: "docker.io/llamaindex/llamacloud-llamaparse-ocr:0.1.47"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          command: ["serve"]
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /health_check
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /health_check
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 4
+              memory: 16Gi
+            requests:
+              cpu: 2
+              memory: 12Gi
+          env:
+          - name: LLAMACLOUD_LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: license-key
+                key: license-key

--- a/charts/llamacloud/kubernetes/llamaparse-ocr/base/pdb.yaml
+++ b/charts/llamacloud/kubernetes/llamaparse-ocr/base/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: llamaparse-ocr
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: llamacloud-llamaparse-ocr

--- a/charts/llamacloud/kubernetes/llamaparse-ocr/base/service.yaml
+++ b/charts/llamacloud/kubernetes/llamaparse-ocr/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: llamaparse-ocr
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/component: llamacloud-llamaparse-ocr

--- a/charts/llamacloud/kubernetes/llamaparse-ocr/base/serviceaccount.yaml
+++ b/charts/llamacloud/kubernetes/llamaparse-ocr/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: llamaparse-ocr

--- a/charts/llamacloud/kubernetes/llamaparse-ocr/kustomization.yaml
+++ b/charts/llamacloud/kubernetes/llamaparse-ocr/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: llamaparse-ocr
+
+namespace: llamacloud
+
+namePrefix: llamacloud-
+
+labels:
+- includeSelectors: true
+  includeTemplates: true
+  pairs:
+    app.kubernetes.io/component: llamacloud-llamaparse-ocr
+    app.kubernetes.io/instance: llamacloud
+    app.kubernetes.io/name: llamacloud
+
+resources:
+- ./base/service.yaml
+- ./base/serviceaccount.yaml
+- ./base/deployment.yaml
+- ./base/pdb.yaml
+
+secretGenerator:
+- files:
+  - license-key
+  options:
+    disableNameSuffixHash: true
+  name: license-key


### PR DESCRIPTION
We are introducing Kustomize bundles as an alternative method of deploying our services in your k8s clusters, starting with llamaparse-ocr!