### PR TITLE
chore: Update kind k8s versions in ci

### DIFF
--- a/.github/workflows/helm_lint_test.yaml
+++ b/.github/workflows/helm_lint_test.yaml
@@ -63,8 +63,8 @@ jobs:
         k8s-version:
           # Limit testing because tests can take a while to run
           # Ref: https://hub.docker.com/r/kindest/node/tags
-          - v1.29.12
-          - v1.31.4
+          - v1.30.10
+          - v1.32.3
 
     steps:
       - name: Checkout


### PR DESCRIPTION
As title describes. We try our best to follow the Standard Support range that the major cloud providers support :)