### PR TITLE
Add missing helm repos to release workflow

### DIFF
--- a/.github/workflows/helm_release_charts.yaml
+++ b/.github/workflows/helm_release_charts.yaml
@@ -29,6 +29,8 @@ jobs:
       - name: Add Helm repositories
         run: |
           helm repo add temporal https://go.temporal.io/helm-charts
+          helm repo add bifrost https://maximhq.github.io/bifrost/helm-charts
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo update
 
       - name: Run chart-releaser


### PR DESCRIPTION
## Summary

The Release Charts workflow was failing with:

> Error: no repository definition for https://maximhq.github.io/bifrost/helm-charts, https://prometheus-community.github.io/helm-charts

`charts/llamacloud/Chart.yaml` declares dependencies on `bifrost` and `kube-prometheus-stack`, but `helm_release_charts.yaml` only ran `helm repo add temporal …` before invoking `chart-releaser`, so helm couldn't resolve those dependencies when packaging the chart.

This adds the two missing `helm repo add` lines so the release workflow matches what `helm_lint_test.yaml` already does.

Failed run: https://github.com/run-llama/helm-charts/actions/runs/26107653375/job/76775878099

## Test plan

- [ ] Merge to `main` and confirm the Release Charts workflow succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai7vPRR35xTMiaE6FuFw9R)_