### PR TITLE
charts/llamacloud: bump bifrost to ~2.1.21, image v1.5.8 (enable airgap pricing mounts)

### DIFF
--- a/charts/llamacloud/CHANGELOG.md
+++ b/charts/llamacloud/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [0.8.2] - 2026-06-04
+
+### Platform
+- **[Feature]** Bump bifrost subchart from `~2.1.16` to `~2.1.21`. Enables airgapped deployments by exposing `bifrost-subchart.bifrost.framework.pricing.modelParametersUrl` (added in bifrost subchart 2.1.17), which lets operators point bifrost at locally-mounted pricing/model-parameters JSON via `file://` URLs without a sidecar mirror pod.
+- **[Feature]** Bump default `bifrost-subchart.image.tag` from `v1.5.0` to `v1.5.8`. v1.5.0 does not support `file://` URLs for pricing data (boot fails with `unsupported protocol scheme "file"`); v1.5.8 does.
+
 ## [0.8.1] - 2026-05-21
 
 ### Frontend

--- a/charts/llamacloud/Chart.lock
+++ b/charts/llamacloud/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.12.3
 - name: bifrost
   repository: https://maximhq.github.io/bifrost/helm-charts
-  version: 2.1.16
+  version: 2.1.21
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 85.0.2
-digest: sha256:d2d78aed620982e9cbb286c90523ef2bc864b7c9eff004a89b17af7588514ced
-generated: "2026-05-12T17:30:29.95099-05:00"
+  version: 85.0.3
+digest: sha256:153dd11f0631b032ab6b756af69e7478a0860762dc2821b3878f92a14ef40238
+generated: "2026-06-04T09:48:31.077662-03:00"

--- a/charts/llamacloud/Chart.lock
+++ b/charts/llamacloud/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 2.1.21
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 85.0.3
-digest: sha256:153dd11f0631b032ab6b756af69e7478a0860762dc2821b3878f92a14ef40238
+  version: 85.0.2
+digest: sha256:edf300259f8858a43e4d971390bac576b47417df5812848e67783c21d81348bf
 generated: "2026-06-04T09:48:31.077662-03:00"

--- a/charts/llamacloud/Chart.yaml
+++ b/charts/llamacloud/Chart.yaml
@@ -23,7 +23,7 @@ keywords:
 - llamacloud
 - rag
 
-version: 0.8.1
+version: 0.8.2
 appVersion: "0.8.1"
 
 dependencies:
@@ -38,7 +38,7 @@ dependencies:
     condition: llamaAgents.deploy
     alias: llama-agents-subchart
   - name: bifrost
-    version: ~2.1.16
+    version: ~2.1.21
     repository: https://maximhq.github.io/bifrost/helm-charts
     condition: bifrost.deploy
     alias: bifrost-subchart

--- a/charts/llamacloud/values.yaml
+++ b/charts/llamacloud/values.yaml
@@ -233,7 +233,7 @@ bifrost:
 bifrost-subchart:
   image:
     ## @param bifrost-subchart.image.tag Bifrost container image tag. Defaults to the appVersion of the pinned bifrost chart. Override to track a different Bifrost release independently of the chart version.
-    tag: "v1.5.0"
+    tag: "v1.5.8"
   bifrost:
     client:
       ## @param bifrost-subchart.bifrost.client.enforceAuthOnInference Require a Bifrost virtual key (sk-bf-*) on inference requests. Defaults to false so the happy-path LlamaCloud integration (configure provider keys under bifrost-subchart.bifrost.providers, then point LlamaCloud at Bifrost via config.llms.providerConfigs with any non-empty placeholder api_key) works out of the box. Set true if you intend to issue per-tenant virtual keys and pass them via the x-bf-vk header.


### PR DESCRIPTION
## Summary

Enables the airgapped bifrost setup described at <https://docs.getbifrost.ai/deployment-guides/how-to/airgapped> without needing a fork or a sidecar mirror pod.

- `Chart.yaml`: bifrost dep `~2.1.16` → `~2.1.21`
- `values.yaml`: `bifrost-subchart.image.tag` `v1.5.0` → `v1.5.8`
- chart `version` `0.8.1` → `0.8.2` (appVersion unchanged — no llamacloud app code changes)
- `Chart.lock` regenerated via `helm dep update`, then kube-prometheus-stack pinned back at 85.0.2 (digest recomputed) so this PR stays strictly scoped to bifrost.

## Why

The bifrost airgap pattern needs **two** things, and the current chart blocks both:

1. **bifrost subchart >= 2.1.17**, which adds `framework.pricing.modelParametersUrl` to the rendered `config.json`. Subchart 2.1.16 only templates `pricing_url`, so an operator setting `modelParametersUrl` in values silently has no effect, and bifrost falls back to fetching model-parameters from the hardcoded `getbifrost.ai` URL — and fatal-crashes in an airgapped cluster.

2. **bifrost image >= the first 1.5.x that supports `file://` URLs** in `framework.pricing.*`. `v1.5.0` does not — boot fails with `unsupported protocol scheme "file"`. `v1.5.8` works. (Could narrow to the first supporting 1.5.x by binary search if you'd prefer a more conservative bump.)

Without both bumps, BYOC operators with no egress to `getbifrost.ai` are stuck running a sidecar nginx mirror to serve the two datasheets — which is what we (LlamaIndex FDE, KPMG engagement) currently do, and it's annoying to maintain through chart upgrades.

## Test plan

Validated locally before opening this PR. Repro:

```bash
# Stage 1 — docker, prove the file:// schema works under zero egress
docker pull maximhq/bifrost:v1.5.0
docker pull maximhq/bifrost:v1.5.8

curl -fsSL -o pricing.json           https://getbifrost.ai/datasheet
curl -fsSL -o model-parameters.json  https://getbifrost.ai/datasheet/model-parameters

cat >config.json <<'JSON'
{ "framework": { "pricing": {
    "pricing_url":          "file:///opt/bifrost/pricing.json",
    "model_parameters_url": "file:///opt/bifrost/model-parameters.json",
    "pricing_sync_interval": 86400
} } }
JSON

for tag in v1.5.0 v1.5.8; do
  docker run --rm --network none \
    -v $PWD/pricing.json:/opt/bifrost/pricing.json:ro \
    -v $PWD/model-parameters.json:/opt/bifrost/model-parameters.json:ro \
    -v $PWD/config.json:/app/data/config.json:ro \
    -e APP_DIR=/app/data -e APP_PORT=8080 -e APP_HOST=0.0.0.0 \
    -e LOG_LEVEL=info -e LOG_STYLE=json \
    maximhq/bifrost:$tag
done
```

- [x] `v1.5.0` → fatal: `failed to download pricing data: Get "file:///opt/bifrost/pricing.json": unsupported protocol scheme "file"`
- [x] `v1.5.8` → boots clean, logs `successfully synced 9859 model parameters records` and `populated model pool with 3019 models across 89 providers`, serves UI

```bash
# Stage 2 — helm + kind, prove the chart wiring lands and the pod boots
cd charts/llamacloud
helm dep build           # uses the pinned lock as-is
helm template bif charts/bifrost-2.1.21.tgz \
  --set image.tag=v1.5.8 \
  --set 'bifrost.framework.pricing.pricingUrl=file:///opt/bifrost/pricing.json' \
  --set 'bifrost.framework.pricing.modelParametersUrl=file:///opt/bifrost/model-parameters.json' \
  | grep -E 'model_parameters_url|pricing_url'
```

- [x] Rendered bifrost configmap contains both `file:///…` URLs (would have been silently dropped before the subchart bump).
- [x] End-to-end: kind cluster with `extraMounts` exposing the two JSONs at `/host-pricing/`, helm-installed bifrost subchart 2.1.21 with `image.tag=v1.5.8` and two `hostPath` volumes mounting the JSONs at `/opt/bifrost/{pricing,model-parameters}.json` — pod Ready in ~30s, no fatal pricing error, no init container required.

## Notes for reviewers

- No `values.schema.json` change needed — `bifrost-subchart.bifrost.framework.pricing.*` is already pass-through (no schema constraints).
- No template changes — the airgap config flows entirely through existing pass-through values into the bifrost subchart's own configmap.
- Production operators still need to mount the two JSONs into the bifrost pod somehow (bake into image, init container, or pre-populated PVC). This PR doesn't add any opinionated mechanism for that — it just unblocks the values that make `file://` work.